### PR TITLE
fix captcha disappear , when validation fails

### DIFF
--- a/resources/views/forms/components/g-recaptcha.blade.php
+++ b/resources/views/forms/components/g-recaptcha.blade.php
@@ -25,6 +25,7 @@
     :state-path="$getStatePath()"
 >
     <div x-data="{ state: $wire.entangle('{{ $getStatePath() }}').defer }"
+         wire:ignore
          x-on:next-wizard-step.window="window.grecaptcha.reset()"
          x-on:expand-concealing-component.window="
                          if (document.body.querySelector('[data-validation-error]') !== null) {


### PR DESCRIPTION
Found a simple fix [on livewire site](https://laravel-livewire.com/docs/2.x/alpine-js#ignoring-dom-changes) for #2 

> To tell Livewire to ignore changes to a subset of HTML within your component, you can add the wire:ignore directive.

